### PR TITLE
usuario com senha vazia

### DIFF
--- a/tests/posterstore-usuariosenhavazia.spec.js
+++ b/tests/posterstore-usuariosenhavazia.spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+//realizando login inválido
+const {
+    test,
+    expect
+} = require('@playwright/test');
+
+test.describe('Criando usuário senha vazia ou inválida', () => {
+    
+    test('Realizando uma compra', async ({
+        page
+    }) => {
+
+        await page.goto('https://poster-store.pages.dev/#');
+        await page.locator('a[id="signup-button"]').click();
+        await page.locator('input[id="swal-username"]').fill('');
+        await page.locator('input[id="swal-password"]').fill('');
+        await page.locator('button[class="swal2-confirm swal2-styled"]').click();
+        await page.waitForSelector(':has-text("Error")');
+    });
+    });
+
+    //teste deu error com sucesso , site ta bugado pois é aceito com a mensagem de sucesso 


### PR DESCRIPTION
Subindo o teste de criação de usuário, sem descrição de usuário e senha. No site Posterstore, essa ação é realizada com sucesso, como se a descrição estivesse preenchida. O teste que vocês verão será um teste negativo.

atualmente o teste apresenta falhas dado que a funcionalidade do site realmente está quebrada e aceitando a criação  do usuário com credencias vazias 